### PR TITLE
Handle authentication between client and server

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
-import './App.css'
-import 'bootstrap/dist/css/bootstrap.min.css'
-import { TournamentView } from './views/TournamentView'
-import { GameView } from './views/GameView'
-import { UserView } from './views/UserView'
-import { NavBar } from './components/NavBar'
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
 import { ThemeProvider } from '@material-ui/styles'
 import { createMuiTheme } from '@material-ui/core/styles'
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+import './App.css'
+import { NavBar } from './components/NavBar'
+import { setToken } from './utils/request'
+import { GameView } from './views/GameView'
+import { TournamentView } from './views/TournamentView'
+import { UserView } from './views/UserView'
 
 // create our material ui theme using up to date typography variables
 const theme = createMuiTheme({
@@ -21,7 +23,19 @@ const theme = createMuiTheme({
   },
 })
 
+const bearerToken = {
+  tokenFromQueryParamsRegexp: /token=([^&]+)/,
+  extractToken(): string | undefined {
+    const match = document.location.search.match(/token=(\w+)/)
+    return match ? match[1] : undefined
+  },
+}
+
 export default function App(): JSX.Element {
+  const token = bearerToken.extractToken()
+  if (token) {
+    setToken(token)
+  }
   return (
     <BrowserRouter>
       <div className="App">

--- a/client/src/hooks/useTournaments.ts
+++ b/client/src/hooks/useTournaments.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import axios from 'axios'
+import { request } from '../utils/request'
 
 export interface Tournament {
   id: number
@@ -15,7 +15,7 @@ export interface Tournament {
 export function useTournaments() {
   const [tournaments, setTournaments] = useState<Tournament[]>([])
   useEffect(() => {
-    axios.get('/api/tournament').then(resp => setTournaments(resp.data))
+    request.get('/api/tournament').then(resp => setTournaments(resp.data))
   }, [])
 
   return tournaments

--- a/client/src/hooks/useUsers.ts
+++ b/client/src/hooks/useUsers.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import axios from 'axios'
+import { request } from '../utils/request'
 
 export interface User {
   discordId: string
@@ -17,7 +17,7 @@ export function useUsers(): User[] {
   const [users, setUsers] = useState<User[]>([])
 
   useEffect(() => {
-    axios.get('/api/user').then(resp => setUsers(resp.data))
+    request.get('/api/user').then(resp => setUsers(resp.data))
   }, [])
 
   return users

--- a/client/src/utils/request.ts
+++ b/client/src/utils/request.ts
@@ -1,0 +1,33 @@
+import axios from 'axios'
+
+const AUTH_TOKEN = 'discordLeagueToken'
+
+export const request = axios
+
+export function setToken(token: string) {
+  window.localStorage.setItem(AUTH_TOKEN, token)
+}
+
+export function unsetToken() {
+  window.localStorage.removeItem(AUTH_TOKEN)
+}
+
+axios.interceptors.request.use(function(config) {
+  const authToken = window.localStorage.getItem(AUTH_TOKEN)
+  if (typeof authToken === 'string') {
+    config.headers = { ...config.headers, Authorization: `Bearer ${authToken}` }
+  }
+  return config
+})
+
+axios.interceptors.response.use(
+  function(response) {
+    return response
+  },
+  function(error) {
+    if (error.response.status === 401) {
+      unsetToken()
+    }
+    return Promise.reject(error)
+  }
+)

--- a/client/src/views/UserView.tsx
+++ b/client/src/views/UserView.tsx
@@ -12,18 +12,6 @@ import {
 import { UserRow } from '../components/UserRow'
 import { useUsers } from '../hooks/useUsers'
 
-export interface UserRecord {
-  discord_id: string
-  discord_name: string
-  discord_discriminator: string
-  discord_avatar: string
-  discord_access_token: string
-  discord_refresh_token: string
-  permissions: number
-  created_at: Date
-  updated_at: Date
-}
-
 export function UserView(): JSX.Element {
   const users = useUsers()
 


### PR DESCRIPTION
After this gets merged, we should always use `utils/request` for our requests instead of `axios`. That will ensure authentication is handled cleanly. 

Closes #22