### PR TITLE
92 drop participant

### DIFF
--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -4,6 +4,6 @@ rm -rf dist
 
 npx tsc --watch > /dev/null &
 
-until [ -f dist/src/index.js ]; do sleep 1; done
+until [ -f dist/index.js ]; do sleep 1; done
 
-npx nodemon --watch dist dist/src/index.js
+npx nodemon --watch dist dist/index.js

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,7 +24,7 @@
     -->
     <title>Discord League</title>
   </head>
-  <body>
+  <body style="background-color:#f0e6e1">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,10 +31,6 @@ export const UserContext = React.createContext<User | undefined>(undefined)
 export default function App(): JSX.Element {
   const user = useCurrentUser()
 
-  useEffect(() => {
-    document.body.style.backgroundColor = '#f0e6e1'
-  })
-
   return (
     <ThemeProvider theme={theme}>
       <UserContext.Provider value={user}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
 import { ThemeProvider } from '@material-ui/styles'
 import { createMuiTheme } from '@material-ui/core/styles'

--- a/client/src/components/PodTable.tsx
+++ b/client/src/components/PodTable.tsx
@@ -35,26 +35,6 @@ const useStyles = makeStyles(() =>
   })
 )
 
-function calculateRecordPerUser(
-  pod: Pod
-): { participantId: number; wins: number; losses: number }[] {
-  return pod.participants.map(participant => {
-    const matchesForParticipant = pod.matches.filter(
-      match => match.playerAId === participant.id || match.playerBId === participant.id
-    )
-    const matchesWon = matchesForParticipant.filter(match => match.winnerId === participant.id)
-    const matchesLost = matchesForParticipant.filter(
-      match => match.winnerId && match.winnerId !== participant.id
-    )
-    return {
-      participantId: participant.id,
-      // To factor in groups smaller than 8
-      wins: matchesWon.length + (8 - pod.participants.length),
-      losses: matchesLost.length,
-    }
-  })
-}
-
 export function PodTable(props: {
   pod: Pod
   onDrop?: (participant: ParticipantWithUserData) => void
@@ -68,14 +48,22 @@ export function PodTable(props: {
     history.push(`/pod/${props.pod.id}`)
   }, [history, props.pod.id])
 
-  const standingsPerUser = calculateRecordPerUser(props.pod)
-  function recordStringForUser(userId: number) {
-    const standing = standingsPerUser.find(standing => userId === standing.participantId)
-    return `${standing?.wins} - ${standing?.losses}`
-  }
-  const sortedParticipants = props.pod.participants.sort((a, b) =>
-    recordStringForUser(a.id) > recordStringForUser(b.id) ? -1 : 1
-  )
+  const sortedParticipants = props.pod.records
+    .slice()
+    .sort((a, b) => {
+      const dropSort = Number(a.dropped) - Number(b.dropped)
+      const winsSort = b.wins - a.wins
+      const lossesSort = b.losses - a.losses
+      return dropSort !== 0 ? dropSort : winsSort !== 0 ? winsSort : lossesSort
+    })
+    .flatMap(record => {
+      const participant = props.pod.participants.find(({ id }) => id === record.participantId)
+      if (!participant) {
+        return []
+      }
+      return { ...participant, wins: record.wins, losses: record.losses }
+    })
+
   return (
     <TableContainer component={Paper}>
       <Table aria-label="customized table" size="small">
@@ -112,12 +100,14 @@ export function PodTable(props: {
                 <UserAvatar
                   userId={participant.userId}
                   userAvatar={participant.discordAvatar}
-                  userName={`${participant.discordName}#${participant.discordDiscriminator}`}
+                  userName={`${participant.dropped ? '💧 ' : ''}${participant.discordName}#${
+                    participant.discordDiscriminator
+                  } `}
                   small
                 />
               </TableCell>
               <TableCell className={classes.sticky}>
-                {recordStringForUser(participant.id)}
+                {`${participant.wins} - ${participant.losses}`}
               </TableCell>
               {props.onDrop && (
                 <TableCell className={classes.sticky} style={{ width: 60, textAlign: 'center' }}>

--- a/client/src/components/PodTable.tsx
+++ b/client/src/components/PodTable.tsx
@@ -66,7 +66,7 @@ export function PodTable(props: {
 
   const navigateToPod = useCallback(() => {
     history.push(`/pod/${props.pod.id}`)
-  }, [props.pod.id])
+  }, [history, props.pod.id])
 
   const standingsPerUser = calculateRecordPerUser(props.pod)
   function recordStringForUser(userId: number) {
@@ -125,7 +125,11 @@ export function PodTable(props: {
                     (isAdmin(currentUser) || participant.userId === currentUser?.discordId) && (
                       <Chip
                         label="Drop"
-                        icon={<span>💧</span>}
+                        icon={
+                          <span role="img" aria-label="Drop">
+                            💧
+                          </span>
+                        }
                         variant="outlined"
                         clickable
                         onClick={() => {

--- a/client/src/hooks/useTournamentParticipants.ts
+++ b/client/src/hooks/useTournamentParticipants.ts
@@ -10,6 +10,7 @@ export interface ParticipantWithUserData {
   discordName: string
   discordAvatar: string
   discordDiscriminator: string
+  dropped: boolean
 }
 
 export function useTournamentParticipants(

--- a/client/src/hooks/useTournamentPod.ts
+++ b/client/src/hooks/useTournamentPod.ts
@@ -1,6 +1,34 @@
 import { useEffect, useState } from 'react'
 import { request } from '../utils/request'
-import { Pod } from './useTournamentPods'
+import { ParticipantWithUserData } from './useTournamentParticipants'
+
+interface Match {
+  id: number
+  createdAt: Date
+  updatedAt: Date
+  deadline: Date
+  playerAId: number
+  playerBId: number
+  winnerId?: number
+  firstPlayerId?: number
+  victoryConditionId?: number
+  deckAClanId: number
+  deckARoleId?: number
+  deckASplashId?: number
+  deckBClanId: number
+  deckBRoleId?: number
+  deckBSplashId?: number
+}
+
+interface Pod {
+  id: number
+  name: string
+  timezoneId: number
+  tournamentId: number
+  matches: Match[]
+  participants: ParticipantWithUserData[]
+  records: Array<{ participantId: number; wins: number; losses: number; dropped: boolean }>
+}
 
 export function useTournamentPod(podId: string | undefined): [Pod | undefined, boolean, string] {
   const [pod, setPod] = useState<Pod>()

--- a/client/src/hooks/useTournamentPods.ts
+++ b/client/src/hooks/useTournamentPods.ts
@@ -24,8 +24,10 @@ export interface Pod {
   id: number
   name: string
   timezoneId: number
+  tournamentId: number
   matches: Match[]
   participants: ParticipantWithUserData[]
+  records: Array<{ participantId: number; wins: number; losses: number; dropped: boolean }>
 }
 
 export function useTournamentPods(tournamentId: number): [Pod[], boolean, string] {

--- a/client/src/hooks/useUsers.ts
+++ b/client/src/hooks/useUsers.ts
@@ -21,8 +21,8 @@ export interface RowUser {
   role: string
 }
 
-export function isAdmin(user: User) {
-  return user.permissions === 1
+export function isAdmin(user?: User) {
+  return user && user.permissions === 1
 }
 
 export function useUsers(): RowUser[] {

--- a/client/src/modals/ConfirmParticipantDrop.tsx
+++ b/client/src/modals/ConfirmParticipantDrop.tsx
@@ -1,0 +1,96 @@
+import { MuiPickersUtilsProvider } from '@material-ui/pickers'
+import React, { useContext } from 'react'
+import DateFnsUtils from '@date-io/date-fns'
+import { Modal, ButtonGroup, Button, makeStyles, Theme, createStyles } from '@material-ui/core'
+import { ParticipantWithUserData } from '../hooks/useTournamentParticipants'
+import { UserContext } from '../App'
+import { displayName } from '../utils/displayName'
+import { User } from '../hooks/useUsers'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    modal: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    paper: {
+      position: 'relative',
+      backgroundColor: theme.palette.background.paper,
+      border: '2px solid #000',
+      boxShadow: theme.shadows[5],
+      padding: theme.spacing(2, 4, 3),
+    },
+    buttonGroup: {
+      position: 'absolute',
+      bottom: theme.spacing(2),
+      right: theme.spacing(2),
+    },
+    inputField: {
+      width: 350,
+    },
+  })
+)
+
+function text2(participant: ParticipantWithUserData, currentUser?: User) {
+  if (currentUser?.discordId === participant.userId) {
+    return {
+      title: 'Do you want to drop from the tournament?',
+      cancel: `Wait, what? No, I don't wanna drop!`,
+      confirm: `Yes, I don't want to play in this tournament anymore.`,
+    }
+  }
+
+  return {
+    title: `Drop ${displayName(participant)} from the tournament?`,
+    cancel: `Oops! No, don't drop them!`,
+    confirm: `Yes, and I double checked that it's the right player`,
+  }
+}
+
+export function ConfirmParticipantDrop(props: {
+  modalOpen: boolean
+  participant?: ParticipantWithUserData
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const classes = useStyles()
+  const currentUser = useContext(UserContext)
+  if (!props.participant) {
+    return null
+  }
+
+  const text = text2(props.participant, currentUser)
+
+  return (
+    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <Modal
+        aria-labelledby="start-tournament-modal-title"
+        aria-describedby="start-tournament-modal-description"
+        open={props.modalOpen}
+        onClose={props.onCancel}
+        className={classes.modal}
+      >
+        <div className={classes.paper}>
+          <h2 id="start-tournament-modal-title">{text.title}</h2>
+          <br />
+          <br />
+          <ButtonGroup className={classes.buttonGroup}>
+            <Button
+              color="inherit"
+              variant="contained"
+              onClick={() => props.onCancel()}
+              style={{ marginRight: 20 }}
+            >
+              {text.cancel}
+            </Button>
+
+            <Button color="secondary" variant="contained" onClick={() => props.onConfirm()}>
+              {text.confirm}
+            </Button>
+          </ButtonGroup>
+        </div>
+      </Modal>
+    </MuiPickersUtilsProvider>
+  )
+}

--- a/client/src/modals/ConfirmParticipantDrop.tsx
+++ b/client/src/modals/ConfirmParticipantDrop.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-function text2(participant: ParticipantWithUserData, currentUser?: User) {
+function textForModal(participant: ParticipantWithUserData, currentUser?: User) {
   if (currentUser?.discordId === participant.userId) {
     return {
       title: 'Do you want to drop from the tournament?',
@@ -60,7 +60,7 @@ export function ConfirmParticipantDrop(props: {
     return null
   }
 
-  const text = text2(props.participant, currentUser)
+  const text = textForModal(props.participant, currentUser)
 
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/client/src/modals/ConfirmParticipantDrop.tsx
+++ b/client/src/modals/ConfirmParticipantDrop.tsx
@@ -22,9 +22,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(2, 4, 3),
     },
     buttonGroup: {
-      position: 'absolute',
-      bottom: theme.spacing(2),
-      right: theme.spacing(2),
+      marginTop: theme.spacing(2),
     },
     inputField: {
       width: 350,
@@ -49,17 +47,12 @@ function textForModal(participant: ParticipantWithUserData, currentUser?: User) 
 }
 
 export function ConfirmParticipantDrop(props: {
-  modalOpen: boolean
-  participant?: ParticipantWithUserData
+  participant: ParticipantWithUserData
   onCancel: () => void
   onConfirm: () => void
 }) {
   const classes = useStyles()
   const currentUser = useContext(UserContext)
-  if (!props.participant) {
-    return null
-  }
-
   const text = textForModal(props.participant, currentUser)
 
   return (
@@ -67,14 +60,12 @@ export function ConfirmParticipantDrop(props: {
       <Modal
         aria-labelledby="start-tournament-modal-title"
         aria-describedby="start-tournament-modal-description"
-        open={props.modalOpen}
+        open
         onClose={props.onCancel}
         className={classes.modal}
       >
         <div className={classes.paper}>
           <h2 id="start-tournament-modal-title">{text.title}</h2>
-          <br />
-          <br />
           <ButtonGroup className={classes.buttonGroup}>
             <Button
               color="inherit"

--- a/client/src/utils/displayName.ts
+++ b/client/src/utils/displayName.ts
@@ -1,0 +1,5 @@
+import { ParticipantWithUserData } from '../hooks/useTournamentParticipants'
+
+export function displayName({ discordName, discordDiscriminator }: ParticipantWithUserData) {
+  return `${discordName}#${discordDiscriminator}`
+}

--- a/client/src/views/PodDetailView.tsx
+++ b/client/src/views/PodDetailView.tsx
@@ -142,12 +142,13 @@ export function PodDetailView() {
         </Paper>
       </Container>
 
-      <ConfirmParticipantDrop
-        modalOpen={state.isDropConfirmationOpen}
-        participant={state.participantBeingDroped}
-        onCancel={() => dispatch({ type: 'dismissDrop' })}
-        onConfirm={() => dispatch({ type: 'dropConfirmed' })}
-      />
+      {state.isDropConfirmationOpen && state.participantBeingDroped && (
+        <ConfirmParticipantDrop
+          participant={state.participantBeingDroped}
+          onCancel={() => dispatch({ type: 'dismissDrop' })}
+          onConfirm={() => dispatch({ type: 'dropConfirmed' })}
+        />
+      )}
     </>
   )
 }

--- a/migrations/20200304201158_add_user_profile_columns.js
+++ b/migrations/20200304201158_add_user_profile_columns.js
@@ -1,15 +1,14 @@
-
 exports.up = function(knex) {
   return knex.schema.table('users', table => {
     table.integer('preferredClanId')
     table.foreign('preferredClanId').references('clans.id')
     table.string('jigokuName')
   })
-};
+}
 
 exports.down = function(knex) {
-  knex.schema.table('users', table => {
+  return knex.schema.table('users', table => {
     table.dropColumn('preferredClanId')
     table.dropColumn('jigokuName')
   })
-};
+}

--- a/migrations/20200411154439_create_participant_drop.js
+++ b/migrations/20200411154439_create_participant_drop.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('participants', function(table) {
+    table
+      .boolean('dropped')
+      .notNullable()
+      .defaultTo(false)
+  })
+}
+
+exports.down = function(knex) {
+  return knex.schema.table('participants', table => {
+    table.dropColumn('dropped')
+  })
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import { ping } from './handlers/ping'
 import * as createTournament from './handlers/createTournament'
 import * as updateTournament from './handlers/updateTournament'
 import * as deleteTournament from './handlers/deleteTournament'
+import * as dropParticipant from './handlers/dropParticipant'
 import * as createParticipant from './handlers/createParticipant'
 import * as updateParticipant from './handlers/updateParticipant'
 import * as updateMatchReport from './handlers/updateMatchReport'
@@ -87,6 +88,9 @@ export default (): AsyncRouterInstance => {
     generatePods.handler
   )
   api.get('/tournament/:tournamentId/pods', getPodsWithMatchesForTournament.handler)
+
+  api.post('/participant/:participantId/drop', authenticate, dropParticipant.handler)
+
   api.get('/pod/:podId', getPodWithMatches.handler)
   api.put(
     '/match/:id/report',

--- a/src/gateways/storage/index.ts
+++ b/src/gateways/storage/index.ts
@@ -13,6 +13,7 @@ export {
   ParticipantRecord,
   ParticipantWithUserData,
   deleteParticipant,
+  dropParticipant,
   fetchMultipleParticipantsWithUserData,
   fetchParticipant,
   fetchParticipants,

--- a/src/gateways/storage/private/participant.ts
+++ b/src/gateways/storage/private/participant.ts
@@ -10,6 +10,7 @@ export interface ParticipantRecord {
   tournamentId: number
   timezoneId: number
   timezonePreferenceId: 'similar' | 'neutral' | 'dissimilar'
+  dropped: boolean
 }
 
 export type ParticipantWithUserData = ParticipantRecord &
@@ -22,6 +23,7 @@ const participantWithUserDataColumns = [
   `${TABLE}.tournamentId as tournamentId`,
   `${TABLE}.timezoneId as timezoneId`,
   `${TABLE}.timezonePreferenceId as timezonePreferenceId`,
+  `${TABLE}.dropped as dropped`,
   `${USERS}.discordName as discordName`,
   `${USERS}.discordAvatar as discordAvatar`,
   `${USERS}.discordDiscriminator as discordDiscriminator`,
@@ -70,7 +72,10 @@ export async function fetchMultipleParticipantsWithUserData(
 }
 
 export async function updateParticipant(
-  participant: Omit<ParticipantRecord, 'createdAt' | 'updatedAt' | 'tournamentId'>
+  participant: Pick<
+    ParticipantRecord,
+    'id' | 'userId' | 'clanId' | 'timezoneId' | 'timezonePreferenceId'
+  >
 ): Promise<ParticipantRecord> {
   const result = await pg(TABLE)
     .where('id', participant.id)
@@ -79,15 +84,19 @@ export async function updateParticipant(
 }
 
 export async function insertParticipant(
-  participant: Omit<ParticipantRecord, 'id'>
+  participant: Pick<
+    ParticipantRecord,
+    'userId' | 'clanId' | 'tournamentId' | 'timezoneId' | 'timezonePreferenceId'
+  >
 ): Promise<ParticipantRecord> {
   return pg(TABLE)
     .insert(participant, '*')
     .then(([row]) => row)
 }
 
-export async function deleteParticipant(id: number): Promise<ParticipantRecord> {
+export async function deleteParticipant(id: number): Promise<void> {
   return pg(TABLE)
     .where('id', id)
     .del()
+    .then(() => undefined)
 }

--- a/src/gateways/storage/private/victoryConditions.ts
+++ b/src/gateways/storage/private/victoryConditions.ts
@@ -1,0 +1,15 @@
+import { pg } from './pg'
+
+export const TABLE = 'victory_conditions'
+
+interface VictoryConditionRecord {
+  id: number
+  name: string
+}
+
+export async function fetchWO(): Promise<VictoryConditionRecord> {
+  return pg(TABLE)
+    .select('*')
+    .where('name', 'W.O.')
+    .first()
+}

--- a/src/handlers/dropParticipant.ts
+++ b/src/handlers/dropParticipant.ts
@@ -1,0 +1,28 @@
+import * as express from 'express-serve-static-core'
+import * as db from '../gateways/storage'
+
+export async function handler(
+  req: express.Request<Record<'participantId', string>>,
+  res: express.Response
+) {
+  const participantId = parseInt(req.params.participantId, 10)
+  if (isNaN(participantId)) {
+    return res.status(400).send('No valid Participant ID was provided.')
+  }
+  if (!req.user?.d_id) {
+    return res.status(401).send('You need to be logged in.')
+  }
+  const requestUser = await db.getUser(req.user.d_id)
+
+  const participant = await db.fetchParticipant(participantId)
+  if (!participant) {
+    return res.status(404).send('Participant could not be found.')
+  }
+  if (requestUser.permissions !== 1 && req.user?.d_id !== participant.userId) {
+    return res.status(403).send('You cannot drop this participations')
+  }
+
+  await db.dropParticipant(participantId)
+
+  res.status(204).send()
+}

--- a/src/handlers/getAllTournaments.ts
+++ b/src/handlers/getAllTournaments.ts
@@ -2,15 +2,6 @@ import * as express from 'express-async-router'
 import * as db from '../gateways/storage'
 
 export async function handler(req: express.Request, res: express.Response) {
-  /**
-  await db.createTournament({
-    name: 'Test Tournament',
-    startDate: new Date(),
-    status: 'upcoming',
-    type: 'monthly',
-    description: 'The test db',
-  })**/
   const tournaments = await db.getAllTournaments()
-
   res.status(200).send(tournaments)
 }

--- a/src/handlers/getPodWithMatches.ts
+++ b/src/handlers/getPodWithMatches.ts
@@ -1,8 +1,8 @@
 import * as express from 'express-async-router'
 import * as db from '../gateways/storage'
-import { MatchRecordWithPodId } from '../gateways/storage'
+import { toPodResults } from '../utils/toPodResults'
 
-function getParticipantIdsForMatches(matches: MatchRecordWithPodId[]): number[] {
+function getParticipantIdsForMatches(matches: db.MatchRecordWithPodId[]): number[] {
   const participantIds: number[] = matches
     .map(match => (match.playerAId && match.playerBId ? [match.playerAId, match.playerBId] : []))
     .reduce((matchA, matchB) => matchA.concat(matchB))
@@ -20,34 +20,5 @@ export async function handler(req: express.Request, res: express.Response) {
   const participantIds = getParticipantIdsForMatches(matches)
   const participants = await db.fetchMultipleParticipantsWithUserData(participantIds)
 
-  const records = matches.reduce(
-    (acc, match) => {
-      const { [match.playerAId]: ra, [match.playerBId]: rb } = acc
-
-      if (ra.dropped !== rb.dropped) {
-        // One of the participants dropped, but not both. Results need to be adjusted
-        const [winner, loser] = ra.dropped ? [rb, ra] : [ra, rb]
-        winner.wins = winner.wins + 1
-        loser.losses = loser.losses + 1
-      } else if (match.winnerId != null) {
-        // There's a match report, follow normal process
-        const [winner, loser] = match.winnerId === ra.participantId ? [ra, rb] : [rb, ra]
-        winner.wins = winner.wins + 1
-        loser.losses = loser.losses + 1
-      }
-
-      return acc
-    },
-    participants.reduce<
-      Record<number, { participantId: number; wins: number; losses: number; dropped: boolean }>
-    >(
-      (initialRecords, { id, dropped }) => ({
-        ...initialRecords,
-        [id]: { participantId: id, wins: 0, losses: 0, dropped: dropped },
-      }),
-      {}
-    )
-  )
-
-  res.status(200).send({ ...pod, matches, participants, records })
+  res.status(200).send(toPodResults(pod, matches, participants))
 }

--- a/src/pods/private/_test_data.ts
+++ b/src/pods/private/_test_data.ts
@@ -8,6 +8,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 2,
@@ -16,6 +17,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 4,
@@ -24,6 +26,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 5,
@@ -32,6 +35,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 7,
@@ -40,6 +44,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 8,
@@ -48,6 +53,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 9,
@@ -56,6 +62,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 10,
@@ -64,6 +71,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 11,
@@ -72,6 +80,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 12,
@@ -80,6 +89,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 13,
@@ -88,6 +98,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 84,
@@ -96,6 +107,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 15,
@@ -104,6 +116,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 18,
@@ -112,6 +125,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 19,
@@ -120,6 +134,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 20,
@@ -128,6 +143,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 21,
@@ -136,6 +152,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 22,
@@ -144,6 +161,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 24,
@@ -152,6 +170,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 25,
@@ -160,6 +179,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 26,
@@ -168,6 +188,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 27,
@@ -176,6 +197,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 28,
@@ -184,6 +206,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 29,
@@ -192,6 +215,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 30,
@@ -200,6 +224,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 33,
@@ -208,6 +233,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 88,
@@ -216,6 +242,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 32,
@@ -224,6 +251,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 35,
@@ -232,6 +260,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 36,
@@ -240,6 +269,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 37,
@@ -248,6 +278,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 38,
@@ -256,6 +287,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 39,
@@ -264,6 +296,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 40,
@@ -272,6 +305,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 41,
@@ -280,6 +314,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 42,
@@ -288,6 +323,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 43,
@@ -296,6 +332,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 44,
@@ -304,6 +341,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 45,
@@ -312,6 +350,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 46,
@@ -320,6 +359,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 48,
@@ -328,6 +368,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 50,
@@ -336,6 +377,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 51,
@@ -344,6 +386,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 52,
@@ -352,6 +395,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 53,
@@ -360,6 +404,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 54,
@@ -368,6 +413,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 55,
@@ -376,6 +422,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 56,
@@ -384,6 +431,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 57,
@@ -392,6 +440,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 58,
@@ -400,6 +449,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 59,
@@ -408,6 +458,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 60,
@@ -416,6 +467,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 61,
@@ -424,6 +476,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 63,
@@ -432,6 +485,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 64,
@@ -440,6 +494,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 65,
@@ -448,6 +503,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 66,
@@ -456,6 +512,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 67,
@@ -464,6 +521,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 68,
@@ -472,6 +530,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 69,
@@ -480,6 +539,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 70,
@@ -488,6 +548,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 71,
@@ -496,6 +557,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 89,
@@ -504,6 +566,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 72,
@@ -512,6 +575,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 73,
@@ -520,6 +584,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 74,
@@ -528,6 +593,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 75,
@@ -536,6 +602,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 76,
@@ -544,6 +611,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 77,
@@ -552,6 +620,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 78,
@@ -560,6 +629,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 79,
@@ -568,6 +638,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 80,
@@ -576,6 +647,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 82,
@@ -584,6 +656,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 85,
@@ -592,6 +665,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 86,
@@ -600,6 +674,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 87,
@@ -608,6 +683,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 90,
@@ -616,6 +692,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 91,
@@ -624,6 +701,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 93,
@@ -632,6 +710,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 106,
@@ -640,6 +719,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 31,
@@ -648,6 +728,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 95,
@@ -656,6 +737,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 96,
@@ -664,6 +746,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 97,
@@ -672,6 +755,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 98,
@@ -680,6 +764,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 100,
@@ -688,6 +773,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 101,
@@ -696,6 +782,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 103,
@@ -704,6 +791,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 104,
@@ -712,6 +800,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 105,
@@ -720,6 +809,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 107,
@@ -728,6 +818,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 110,
@@ -736,6 +827,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 108,
@@ -744,6 +836,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 109,
@@ -752,6 +845,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 16,
@@ -760,6 +854,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 94,
@@ -768,6 +863,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 47,
@@ -776,6 +872,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 81,
@@ -784,6 +881,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 6,
@@ -792,6 +890,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 17,
@@ -800,6 +899,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 23,
@@ -808,6 +908,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 83,
@@ -816,6 +917,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 112,
@@ -824,6 +926,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 113,
@@ -832,6 +935,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 114,
@@ -840,6 +944,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 115,
@@ -848,6 +953,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 116,
@@ -856,6 +962,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 117,
@@ -864,6 +971,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 118,
@@ -872,6 +980,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 119,
@@ -880,6 +989,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 120,
@@ -888,6 +998,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 121,
@@ -896,6 +1007,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 122,
@@ -904,6 +1016,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 123,
@@ -912,6 +1025,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 124,
@@ -920,6 +1034,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 125,
@@ -928,6 +1043,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 126,
@@ -936,6 +1052,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 127,
@@ -944,6 +1061,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 128,
@@ -952,6 +1070,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 129,
@@ -960,6 +1079,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 131,
@@ -968,6 +1088,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 132,
@@ -976,6 +1097,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 133,
@@ -984,6 +1106,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 7,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 134,
@@ -992,6 +1115,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 5,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 135,
@@ -1000,6 +1124,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 136,
@@ -1008,6 +1133,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 137,
@@ -1016,6 +1142,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 138,
@@ -1024,6 +1151,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 4,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 139,
@@ -1032,6 +1160,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 140,
@@ -1040,6 +1169,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 6,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 141,
@@ -1048,6 +1178,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 142,
@@ -1056,6 +1187,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 3,
     timezonePreferenceId: 'neutral',
+    dropped: false,
   },
   {
     id: 143,
@@ -1064,6 +1196,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 1,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 144,
@@ -1072,6 +1205,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
   {
     id: 145,
@@ -1080,6 +1214,7 @@ const d: ParticipantRecord[] = [
     tournamentId: 1,
     timezoneId: 2,
     timezonePreferenceId: 'similar',
+    dropped: false,
   },
 ]
 

--- a/src/pods/private/groupParticipantsInPods.spec.ts
+++ b/src/pods/private/groupParticipantsInPods.spec.ts
@@ -17,6 +17,7 @@ const arbitrary = {
         opts?.timezonePreferenceId != null
           ? fc.constant(opts.timezonePreferenceId)
           : fc.constantFrom('similar', 'neutral', 'dissimilar'),
+      dropped: fc.boolean(),
     })
   },
 }

--- a/src/utils/toPodResults.ts
+++ b/src/utils/toPodResults.ts
@@ -1,0 +1,41 @@
+import * as db from '../gateways/storage'
+
+export function toPodResults(
+  pod: db.TournamentPodRecord,
+  allMatches: db.MatchRecordWithPodId[],
+  allParticipants: db.ParticipantWithUserData[]
+) {
+  const matches = allMatches.filter(match => match.podId === pod.id)
+  const participants = allParticipants.filter(participant =>
+    matches.some(match => participant.id === match.playerAId || participant.id === match.playerBId)
+  )
+  const records = allMatches.reduce(
+    (acc, match) => {
+      const { [match.playerAId]: ra, [match.playerBId]: rb } = acc
+
+      if (ra.dropped !== rb.dropped) {
+        // One of the participants dropped, but not both. Results need to be adjusted
+        const [winner, loser] = ra.dropped ? [rb, ra] : [ra, rb]
+        winner.wins = winner.wins + 1
+        loser.losses = loser.losses + 1
+      } else if (match.winnerId != null) {
+        // There's a match report, follow normal process
+        const [winner, loser] = match.winnerId === ra.participantId ? [ra, rb] : [rb, ra]
+        winner.wins = winner.wins + 1
+        loser.losses = loser.losses + 1
+      }
+
+      return acc
+    },
+    allParticipants.reduce<
+      Record<number, { participantId: number; wins: number; losses: number; dropped: boolean }>
+    >(
+      (initialRecords, { id, dropped }) => ({
+        ...initialRecords,
+        [id]: { participantId: id, wins: 0, losses: 0, dropped: dropped },
+      }),
+      {}
+    )
+  )
+  return { ...pod, matches, participants, records: Object.values(records) }
+}


### PR DESCRIPTION
When a player is dropped all their unplayed matches get reported as victories to their opponents as W.O. victories, and the player gets a `dropped` flag on his `participant` entry.

When displaying results, each of their matches (played or unplayed) gets counted as a win for their opponent.

The reasoning is we keep data integrity about the player's performance, just using the drop for tournament effects.

The UI offer the drop button on the pod details screen. It is available for all users on their own row or on each row for admins.

A drop is not reversible. It can be undone directly in the database if needed, but there's no automated way for it.

![Screen Shot 2020-04-19 at 09 15 51](https://user-images.githubusercontent.com/934678/79681900-6c8c8680-821e-11ea-9c52-a8d81670bd3b.png)

![Screen Shot 2020-04-19 at 09 15 59](https://user-images.githubusercontent.com/934678/79681901-6eeee080-821e-11ea-8205-5d343632be74.png)
