### PR TITLE
show decklists after tournament enters bracket/finished stage

### DIFF
--- a/client/src/views/TournamentDetailView/TournamentDetail.tsx
+++ b/client/src/views/TournamentDetailView/TournamentDetail.tsx
@@ -77,7 +77,7 @@ export function TournamentDetail({
       <Container>
         <Paper>
           <TournamentHeaderPanel tournament={tournament} />
-          {tournament.statusId === 'endOfGroup' && (
+          {tournament.statusId !== 'upcoming' && tournament.statusId !== 'group' && (
             <TournamentCupClassification tournamentId={tournament.id} participants={participants} />
           )}
           {tournament.statusId !== 'upcoming' && (


### PR DESCRIPTION
Fixes a bug that decklists aren't viewable after a tournament is finished