### PR TITLE
Deleting a participant deletes their matches first

### DIFF
--- a/src/gateways/storage/index.ts
+++ b/src/gateways/storage/index.ts
@@ -15,6 +15,7 @@ export {
   insertMatch,
   updateMatch,
   deleteMatchReport,
+  deleteMatches
 } from './private/match'
 
 export {

--- a/src/gateways/storage/private/match.ts
+++ b/src/gateways/storage/private/match.ts
@@ -110,3 +110,10 @@ export async function deleteMatchReport(matchId: number): Promise<MatchRecord> {
     )
   return result[0]
 }
+
+export async function deleteMatches(matchIds: number[]): Promise<void> {
+  return pg(TABLE)
+    .whereIn('id', matchIds)
+    .del()
+    .then(() => undefined)
+}

--- a/src/handlers/deleteParticipant.ts
+++ b/src/handlers/deleteParticipant.ts
@@ -23,6 +23,10 @@ export async function handler(req: express.Request, res: express.Response) {
     res.status(403).send('You cannot delete participations for this user.')
     return
   }
+  let matches = await db.fetchMatchesForMultipleParticipants([participationId]);
+  if (matches) {
+    await db.deleteMatches(matches.map(match => match.id))
+  }
   await db.deleteParticipant(participationId)
 
   res.status(204).send()


### PR DESCRIPTION
This allows us to delete participants that are already seeded in a pod. Before deleting the participation itself, we look for any matches of that participant and delete those. Then we proceed to delete the participant as usual.