### PR TITLE
New ranking

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,9 +1,13 @@
-/* eslint-disable */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const url = require('url')
 const dotenv = require('dotenv')
 
 dotenv.config()
 
-const [,user, password, host, port, database] = (/^postgres:\/\/([^:]+):([^@]+)@([^:]+):([^/]+)\/(.+)$/).exec(process.env.DATABASE_URL)
+const { username: user, password, hostname: host, port, pathname } = new url.URL(
+  process.env.DATABASE_URL
+)
+const database = pathname.slice(1)
 
 module.exports = {
   development: {
@@ -28,8 +32,8 @@ module.exports = {
       port: parseInt(port, 10),
       database,
       ssl: {
-        rejectUnauthorized: false
-      }
+        rejectUnauthorized: false,
+      },
     },
     migrations: {
       tableName: 'knex_migrations',

--- a/migrations/20210109142803_create_pod6_tournament_type.js
+++ b/migrations/20210109142803_create_pod6_tournament_type.js
@@ -1,0 +1,10 @@
+
+exports.up = function(knex) {
+  return knex('tournament_types').insert([{ id: 'pod6', name: 'Monthly 2021' }])
+};
+
+exports.down = function(knex) {
+  return knex('tournament_types')
+    .whereIn('id', 'pod6')
+    .delete()
+};

--- a/src/gateways/storage/index.ts
+++ b/src/gateways/storage/index.ts
@@ -48,9 +48,10 @@ export {
   createTournament,
   deleteTournament,
   fetchTournament,
+  fetchTournaments,
   getAllTournaments,
   getTournament,
-  fetchTournaments,
+  TournamentRecord,
   updateTournament,
 } from './private/tournament'
 

--- a/src/gateways/storage/private/participant.ts
+++ b/src/gateways/storage/private/participant.ts
@@ -1,7 +1,5 @@
 import { pg } from './pg'
 import { UserRecord, TABLE as USERS } from './user'
-import { TABLE as MATCHES } from './match'
-import { fetchWO } from './victoryConditions'
 
 export const TABLE = 'participants'
 

--- a/src/gateways/storage/private/pg.ts
+++ b/src/gateways/storage/private/pg.ts
@@ -3,7 +3,9 @@ import knex, { RawBinding } from 'knex'
 
 import env from '../../../env'
 
-const { username: user, password, hostname: host, port, pathname } = new url.URL(env.databaseUrl)
+const databaseUrl =
+  env.nodeEnv === 'test' ? 'postgres://user:password@host:1337/dbname' : env.databaseUrl
+const { username: user, password, hostname: host, port, pathname } = new url.URL(databaseUrl)
 const database = pathname.slice(1)
 
 export const pg = knex({

--- a/src/gateways/storage/private/pg.ts
+++ b/src/gateways/storage/private/pg.ts
@@ -1,9 +1,10 @@
+import url from 'url'
 import knex, { RawBinding } from 'knex'
 
 import env from '../../../env'
 
-const [, user, password, host, port, database] =
-  /^postgres:\/\/([^:]+):([^@]+)@([^:]+):([^/]+)\/(.+)$/.exec(env.databaseUrl) || []
+const { username: user, password, hostname: host, port, pathname } = new url.URL(env.databaseUrl)
+const database = pathname.slice(1)
 
 export const pg = knex({
   client: 'pg',

--- a/src/gateways/storage/private/pod.ts
+++ b/src/gateways/storage/private/pod.ts
@@ -21,6 +21,6 @@ export async function fetchTournamentPods(tournamentId: number): Promise<Tournam
   return pg(TABLE).where('tournamentId', tournamentId)
 }
 
-export async function fetchPod(podId: number): Promise<TournamentPodRecord> {
+export async function fetchPod(podId: number): Promise<TournamentPodRecord | undefined> {
   return pg(TABLE).where('id', podId).first()
 }

--- a/src/gateways/storage/private/tournament.ts
+++ b/src/gateways/storage/private/tournament.ts
@@ -13,7 +13,7 @@ export interface TournamentRecord {
   updatedAt: Date
 }
 
-export async function getTournament(id: string): Promise<TournamentRecord> {
+export async function getTournament(id: string): Promise<TournamentRecord | undefined> {
   return pg(TABLE).select('*').where('id', id).first()
 }
 

--- a/src/gateways/storage/private/tournament.ts
+++ b/src/gateways/storage/private/tournament.ts
@@ -7,7 +7,7 @@ export interface TournamentRecord {
   name: string
   startDate: Date
   statusId: 'upcoming' | 'group' | 'endOfGroup' | 'bracket' | 'finished'
-  typeId: 'monthly'
+  typeId: 'monthly' | 'pod6'
   description?: string
   createdAt: Date
   updatedAt: Date

--- a/src/handlers/createTournament.ts
+++ b/src/handlers/createTournament.ts
@@ -9,13 +9,13 @@ export const schema = {
     name: string
     startDate: Date
     status: 'upcoming' | 'group' | 'endOfGroup' | 'bracket' | 'finished'
-    type: 'monthly'
+    type: 'monthly' | 'pod6'
     description?: string
   }>({
     name: Joi.string().required(),
     startDate: Joi.date().required(),
     status: Joi.string().valid('upcoming', 'group', 'endOfGroup', 'bracket', 'finished').required(),
-    type: Joi.string().valid('monthly').required(),
+    type: Joi.string().valid('monthly', 'pod6').required(),
     description: Joi.string().allow('').optional(),
   }),
 }

--- a/src/handlers/getTournament.ts
+++ b/src/handlers/getTournament.ts
@@ -1,15 +1,39 @@
-import * as express from 'express-async-router'
+import * as express from 'express'
 import * as db from '../gateways/storage'
+import { toTournament, PodResult } from '../tournaments'
 
-export async function handler(req: express.Request, res: express.Response): Promise<void> {
-  if (!req.params.id) {
-    res.status(400).send()
+type Request = express.Request<{ id: string }>
+type Response = express.Response<{
+  tournament: {
+    id: number
+    name: string
+    startDate: Date
+    statusId: 'upcoming' | 'group' | 'endOfGroup' | 'bracket' | 'finished'
+    typeId: 'monthly' | 'pod6'
+    description?: string
+    createdAt: Date
+    updatedAt: Date
+  }
+  pods: PodResult[]
+}>
+
+function getParticipantIdsForMatches(matches: db.MatchRecordWithPodId[]): number[] {
+  return Array.from(new Set(matches.flatMap((match) => [match.playerAId, match.playerBId])))
+}
+
+export async function handler(req: Request, res: Response): Promise<void> {
+  const tournamentRecord = await db.getTournament(req.params.id)
+  if (!tournamentRecord) {
+    res.status(404).send()
     return
   }
-  const tournament = await db.getTournament(req.params.id)
-  if (tournament) {
-    res.status(200).send(tournament)
-    return
-  }
-  res.status(404).send()
+  const podRecords = await db.fetchTournamentPods(tournamentRecord.id)
+  const matchRecords = await db.fetchMatchesForMultiplePods(podRecords.map((pod) => pod.id))
+  const participantRecords = await db.fetchMultipleParticipantsWithUserData(
+    getParticipantIdsForMatches(matchRecords)
+  )
+
+  const tournament = toTournament(tournamentRecord, podRecords, matchRecords, participantRecords)
+
+  res.status(200).send({ tournament: tournamentRecord, pods: tournament.toPodResults() })
 }

--- a/src/handlers/getTournament.ts
+++ b/src/handlers/getTournament.ts
@@ -17,10 +17,6 @@ type Response = express.Response<{
   pods: PodResult[]
 }>
 
-function getParticipantIdsForMatches(matches: db.MatchRecordWithPodId[]): number[] {
-  return Array.from(new Set(matches.flatMap((match) => [match.playerAId, match.playerBId])))
-}
-
 export async function handler(req: Request, res: Response): Promise<void> {
   const tournamentRecord = await db.getTournament(req.params.id)
   if (!tournamentRecord) {
@@ -30,7 +26,7 @@ export async function handler(req: Request, res: Response): Promise<void> {
   const podRecords = await db.fetchTournamentPods(tournamentRecord.id)
   const matchRecords = await db.fetchMatchesForMultiplePods(podRecords.map((pod) => pod.id))
   const participantRecords = await db.fetchMultipleParticipantsWithUserData(
-    getParticipantIdsForMatches(matchRecords)
+    matchRecords.flatMap((match) => [match.playerAId, match.playerBId])
   )
 
   const tournament = toTournament(tournamentRecord, podRecords, matchRecords, participantRecords)

--- a/src/handlers/updateTournament.ts
+++ b/src/handlers/updateTournament.ts
@@ -9,7 +9,7 @@ export const schema = {
     name: string
     startDate: Date
     statusId: 'upcoming' | 'group' | 'endOfGroup' | 'bracket' | 'finished'
-    typeId: 'monthly'
+    typeId: 'monthly' | 'pod6'
     description?: string
   }>({
     name: Joi.string().required(),
@@ -17,7 +17,7 @@ export const schema = {
     statusId: Joi.string()
       .valid('upcoming', 'group', 'endOfGroup', 'bracket', 'finished')
       .required(),
-    typeId: Joi.string().valid('monthly').required(),
+    typeId: Joi.string().valid('monthly', 'pod6').required(),
     description: Joi.string().allow('').optional(),
   }),
 }

--- a/src/pods/private/ranking.ts
+++ b/src/pods/private/ranking.ts
@@ -12,10 +12,12 @@ interface MatchProps {
   updatedAt: Date
 }
 
+type MinimalPlayer = Pick<Player, 'id'>
+
 class Wrapper {
   private matches: MatchProps[] = []
   public played = 0
-  private constructor(private player: Player, allMatches: MatchProps[]) {
+  private constructor(private player: MinimalPlayer, allMatches: MatchProps[]) {
     allMatches.forEach((match) => {
       if (this.player.id === match.playerAId || this.player.id === match.playerBId) {
         this.matches.push(match)
@@ -27,11 +29,11 @@ class Wrapper {
   }
 
   static wrapWithMatches(allMatches: MatchProps[]) {
-    return (player: Player) => new Wrapper(player, allMatches)
+    return <P extends MinimalPlayer>(player: P) => new Wrapper(player, allMatches)
   }
 
   static unwrap(wrapper: Wrapper): Player {
-    return wrapper.player
+    return wrapper.player as Player
   }
 
   get id() {
@@ -90,7 +92,10 @@ const splitByFirstWin = (players: Wrapper[]) =>
     .sort((playerA, playerB) => playerB.firstWinDate - playerA.firstWinDate)
     .map((player) => [player])
 
-export function rankPodParticipants(players: Player[], matches: Match[]): Player[] {
+export function rankPodParticipants<P extends MinimalPlayer>(
+  players: P[],
+  matches: Match[]
+): Player[] {
   const wrappers = players.map(Wrapper.wrapWithMatches(matches))
 
   return pipe(

--- a/src/tournaments/index.ts
+++ b/src/tournaments/index.ts
@@ -1,0 +1,2 @@
+export { toTournament } from './private/tournamentFactory'
+export { PodResult } from './private/types'

--- a/src/tournaments/private/leagueBase.ts
+++ b/src/tournaments/private/leagueBase.ts
@@ -1,0 +1,89 @@
+import {
+  TournamentData,
+  PodData,
+  MatchData,
+  ParticipantData,
+  PlayerRecord,
+  PodResult,
+  ExtendedParticipant,
+  RankedParticipant,
+} from './types'
+
+export abstract class LeagueBase {
+  constructor(
+    protected tournament: TournamentData,
+    protected pods: PodData[],
+    protected matches: MatchData[],
+    protected participants: ParticipantData[]
+  ) {}
+
+  private getMatches(pod: PodData): MatchData[] {
+    return this.matches.filter((match) => match.podId === pod.id)
+  }
+
+  private getParticipants(pod: PodData): ParticipantData[] {
+    return this.participants.filter((participant) =>
+      this.matches.some(
+        (match) =>
+          match.podId === pod.id &&
+          (participant.id === match.playerAId || participant.id === match.playerBId)
+      )
+    )
+  }
+
+  protected get isPodStageDone(): boolean {
+    return (
+      this.tournament.statusId === 'endOfGroup' ||
+      this.tournament.statusId === 'bracket' ||
+      this.tournament.statusId === 'finished'
+    )
+  }
+
+  protected abstract playerRecordReduce(
+    records: Record<number, PlayerRecord>,
+    match: MatchData
+  ): Record<number, PlayerRecord>
+
+  protected calcRecords(
+    podParticipants: ParticipantData[],
+    podMatches: MatchData[]
+  ): PlayerRecord[] {
+    return Object.values(
+      podMatches.reduce(
+        (records: Record<number, PlayerRecord>, match: MatchData) =>
+          this.playerRecordReduce(records, match),
+        podParticipants.reduce<Record<number, PlayerRecord>>(
+          (initialRecords, player) => ({
+            ...initialRecords,
+            [player.id]: { participantId: player.id, dropped: player.dropped, wins: 0, losses: 0 },
+          }),
+          {}
+        )
+      )
+    )
+  }
+
+  protected abstract rankParticipants(
+    extendedParticipants: ExtendedParticipant[],
+    matches: MatchData[]
+  ): RankedParticipant[]
+
+  public toPodResults(): PodResult[] {
+    return this.pods.map((pod) => {
+      const matches = this.getMatches(pod)
+      const participants = this.getParticipants(pod)
+      const records = this.calcRecords(participants, matches)
+      const extendedParticipants = participants.map((participant) => ({
+        ...participant,
+        ...(records.find((record) => participant.id === record.participantId) ?? {
+          wins: 0,
+          losses: 0,
+          participantId: participant.id,
+        }),
+      }))
+      const rankedParticipants = this.rankParticipants(extendedParticipants, matches)
+
+      return { ...pod, matches, participants: rankedParticipants }
+    })
+  }
+}

--- a/src/tournaments/private/monthly.ts
+++ b/src/tournaments/private/monthly.ts
@@ -1,0 +1,51 @@
+import * as A from 'fp-ts/lib/Array'
+import { pipe } from 'fp-ts/lib/function'
+import { contramap, ordNumber } from 'fp-ts/lib/Ord'
+
+import { LeagueBase } from './leagueBase'
+import { PlayerRecord, MatchData, ExtendedParticipant, RankedParticipant } from './types'
+
+const byWinsDESC = contramap<number, ExtendedParticipant>((p) => -p.wins)(ordNumber)
+const byGamesPlayedDESC = contramap<number, ExtendedParticipant>((p) => -(p.wins + p.losses))(
+  ordNumber
+)
+
+export class MonthlyTournament extends LeagueBase {
+  protected playerRecordReduce(
+    records: Record<number, PlayerRecord>,
+    match: MatchData
+  ): Record<number, PlayerRecord> {
+    const { [match.playerAId]: recordPlayerA, [match.playerBId]: recordPlayerB } = records
+
+    if (recordPlayerA.dropped !== recordPlayerB.dropped) {
+      // One of the participants dropped, but not both. Results need to be adjusted
+      const [winner, loser] = recordPlayerA.dropped
+        ? [recordPlayerB, recordPlayerA]
+        : [recordPlayerA, recordPlayerB]
+      winner.wins = winner.wins + 1
+      loser.losses = loser.losses + 1
+    } else if (match.winnerId != null) {
+      // There's a match report, follow normal process
+      const [winnerRecord, loserRecord] =
+        match.winnerId === recordPlayerA.participantId
+          ? [recordPlayerA, recordPlayerB]
+          : [recordPlayerB, recordPlayerA]
+      winnerRecord.wins = winnerRecord.wins + 1
+      loserRecord.losses = loserRecord.losses + 1
+    } else if (this.isPodStageDone) {
+      // enforce double loss to unplayed matches
+      recordPlayerA.losses = recordPlayerA.losses + 1
+      recordPlayerB.losses = recordPlayerB.losses + 1
+    }
+
+    return records
+  }
+
+  protected rankParticipants(extendedParticipants: ExtendedParticipant[]): RankedParticipant[] {
+    return pipe(
+      extendedParticipants,
+      A.sortBy([byWinsDESC, byGamesPlayedDESC]),
+      A.mapWithIndex((idx, ep) => ({ ...ep, position: idx + 1 }))
+    )
+  }
+}

--- a/src/tournaments/private/pod6.ts
+++ b/src/tournaments/private/pod6.ts
@@ -1,0 +1,34 @@
+import { LeagueBase } from './leagueBase'
+import { PlayerRecord, MatchData, ExtendedParticipant, RankedParticipant } from './types'
+import { rankPodParticipants } from '../../pods'
+
+export class Pod6Tournament extends LeagueBase {
+  protected playerRecordReduce(
+    records: Record<number, PlayerRecord>,
+    match: MatchData
+  ): Record<number, PlayerRecord> {
+    const { [match.playerAId]: recordPlayerA, [match.playerBId]: recordPlayerB } = records
+    if (match.winnerId != null) {
+      const [winnerRecord, loserRecord] =
+        match.winnerId === recordPlayerA.participantId
+          ? [recordPlayerA, recordPlayerB]
+          : [recordPlayerB, recordPlayerA]
+      winnerRecord.wins = winnerRecord.wins + 1
+      loserRecord.losses = loserRecord.losses + 1
+    }
+
+    return records
+  }
+
+  protected rankParticipants(
+    extendedParticipants: ExtendedParticipant[],
+    matches: MatchData[]
+  ): RankedParticipant[] {
+    const rankedParticipants = rankPodParticipants(extendedParticipants, matches)
+    return rankedParticipants.flatMap(({ id }, idx) => ({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      ...extendedParticipants.find((extendedParticipant) => id === extendedParticipant.id)!,
+      position: idx + 1,
+    }))
+  }
+}

--- a/src/tournaments/private/tournamentFactory.ts
+++ b/src/tournaments/private/tournamentFactory.ts
@@ -1,0 +1,17 @@
+import { MonthlyTournament } from './monthly'
+import { Pod6Tournament } from './pod6'
+import { TournamentData, PodData, MatchData, ParticipantData } from './types'
+
+export function toTournament(
+  tournament: TournamentData,
+  pods: PodData[],
+  matches: MatchData[],
+  participants: ParticipantData[]
+): MonthlyTournament | Pod6Tournament {
+  switch (tournament.typeId) {
+    case 'monthly':
+      return new MonthlyTournament(tournament, pods, matches, participants)
+    case 'pod6':
+      return new Pod6Tournament(tournament, pods, matches, participants)
+  }
+}

--- a/src/tournaments/private/types.ts
+++ b/src/tournaments/private/types.ts
@@ -1,0 +1,41 @@
+import * as db from '../../gateways/storage'
+
+export type MatchData = db.MatchRecordWithPodId
+
+export type ParticipantData = db.ParticipantWithUserData
+
+export type TournamentData = db.TournamentRecord
+
+export interface PlayerRecord {
+  participantId: number
+  dropped: boolean
+  wins: number
+  losses: number
+}
+
+export type ExtendedParticipant = Pick<
+  ParticipantData,
+  | 'id'
+  | 'userId'
+  | 'clanId'
+  | 'dropped'
+  | 'discordId'
+  | 'discordDiscriminator'
+  | 'discordAvatar'
+  | 'discordName'
+> &
+  Pick<PlayerRecord, 'wins' | 'losses'>
+
+export type RankedParticipant = ExtendedParticipant & { position: number }
+
+export interface PodResult extends db.TournamentPodRecord {
+  matches: MatchData[]
+  participants: Array<RankedParticipant>
+}
+
+export interface PodData {
+  id: number
+  name: string
+  tournamentId: number
+  timezoneId: number
+}


### PR DESCRIPTION
Tournament rules live in `src/tournaments`, as we start having different tournament types we can centralize the rules in tournament classes.

It might make sense to move the ranking logic from the Pods module into Tournaments module, but it was gonna be too much moving around for now, so I just left it there.

- GET /tournament/:id returns a lot more data, with participants, matches, records, everything we should need to display one tournament. I think that can cleanup a lot of stuff in the client side.
- GET /pod/:id also returns more stuff, like for /tournament

Both endpoints should be backwards compatible, so we could merge this before any client changes with no problem.

Bonus:
- cleanup the database connections to not rely on regex
- got rid of `getParticipantIdsForMatches` in a few endpoints. It's just a flatMap, no need for fancy functions. 